### PR TITLE
Small changes to allow new rompy to run with SWAN

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -8,7 +8,7 @@ recursive-include rompy *.png
 recursive-include docs/source *
 include docs/Makefile docs/make.bat
 
-recursive-include templates *
+recursive-include rompy/templates *
 
 include versioneer.py
 include rompy/_version.py

--- a/rompy/swan/config.py
+++ b/rompy/swan/config.py
@@ -213,10 +213,10 @@ class Outputs(RompyBaseModel):
         ret = "OUTPUT OPTIONS BLOCK 8\n"
         ret += f"BLOCK 'COMPGRID' HEADER 'outputs/swan_out.nc' LAYOUT 1 {' '.join(self.grid.variables)} OUT {self.grid.period.start.strftime(self._datefmt)} {out_intvl}\n"
         ret += "\n"
-        if self.spec.locations:
+        if len(self.spec.locations.coords) > 0:
             ret += f"POINTs 'pts' FILE 'out.loc'\n"
-        ret += f"SPECout 'pts' SPEC2D ABS 'outputs/spec_out.nc' OUTPUT {self.spec.period.start.strftime(self._datefmt)} {out_intvl}\n"
-        ret += f"TABle 'pts' HEADer 'outputs/tab_out.nc' TIME XP YP HS TPS TM01 DIR DSPR WIND OUTPUT {self.grid.period.start.strftime(self._datefmt)} {out_intvl}\n"
+            ret += f"SPECout 'pts' SPEC2D ABS 'outputs/spec_out.nc' OUTPUT {self.spec.period.start.strftime(self._datefmt)} {out_intvl}\n"
+            ret += f"TABle 'pts' HEADer 'outputs/tab_out.nc' TIME XP YP HS TPS TM01 DIR DSPR WIND OUTPUT {self.grid.period.start.strftime(self._datefmt)} {out_intvl}\n"
         return ret
 
     def __str__(self):


### PR DESCRIPTION
- include templates in package
- don't produce any directives for model control file if there are no spectral output locations
- subcomponents need to be included in package